### PR TITLE
Revert editing changes; Test revert functionality

### DIFF
--- a/app/components/reminder-form.js
+++ b/app/components/reminder-form.js
@@ -24,6 +24,14 @@ export default Ember.Component.extend({
           this.setProperties({ title: '', date: '', notes: '' });
         });
       }
+    },
+    revert(model, id) {
+        if(model.get('hasDirtyAttributes')) {
+          this.get('store').findRecord('reminder', id).then((record) => {
+            record.rollback()
+          });
+          model.rollbackAttributes()
+        }
+      },
     }
-  }
 });

--- a/app/components/reminder-form.js
+++ b/app/components/reminder-form.js
@@ -27,9 +27,6 @@ export default Ember.Component.extend({
     },
     revert(model) {
         if(model.get('hasDirtyAttributes')) {
-          this.get('store').findRecord('reminder', model.id).then((reminder) => {
-            reminder.rollbackAttributes()
-          });
           model.rollbackAttributes()
         }
       },

--- a/app/components/reminder-form.js
+++ b/app/components/reminder-form.js
@@ -25,10 +25,10 @@ export default Ember.Component.extend({
         });
       }
     },
-    revert(model, id) {
+    revert(model) {
         if(model.get('hasDirtyAttributes')) {
-          this.get('store').findRecord('reminder', id).then((record) => {
-            record.rollback()
+          this.get('store').findRecord('reminder', model.id).then((reminder) => {
+            reminder.rollbackAttributes()
           });
           model.rollbackAttributes()
         }

--- a/app/templates/components/reminder-form.hbs
+++ b/app/templates/components/reminder-form.hbs
@@ -14,6 +14,5 @@
 {{outlet}}
 
 {{#if edit}}
-  <button class="revert-changes-button" {{action 'revert' model on="click"}}>Revert Changes</button>
-  {{!-- <button class="revert-changes-button {{if reminder.hasDirtyAttributes "enabled"}}" {{action 'revert' reminder on="click"}}>Revert</button> --}}
+  <button class="revert-changes-button" {{action 'revert' model}}>Revert Changes</button>
 {{/if}}

--- a/app/templates/components/reminder-form.hbs
+++ b/app/templates/components/reminder-form.hbs
@@ -12,3 +12,8 @@
 </form>
 
 {{outlet}}
+
+{{#if edit}}
+  <button class="revert-changes-button" {{action 'revert' model id on="click"}}>Revert Changes</button>
+  {{!-- <button class="revert-changes-button {{if reminder.hasDirtyAttributes "enabled"}}" {{action 'revert' reminder on="click"}}>Revert</button> --}}
+{{/if}}

--- a/app/templates/components/reminder-form.hbs
+++ b/app/templates/components/reminder-form.hbs
@@ -14,6 +14,6 @@
 {{outlet}}
 
 {{#if edit}}
-  <button class="revert-changes-button" {{action 'revert' model id on="click"}}>Revert Changes</button>
+  <button class="revert-changes-button" {{action 'revert' model on="click"}}>Revert Changes</button>
   {{!-- <button class="revert-changes-button {{if reminder.hasDirtyAttributes "enabled"}}" {{action 'revert' reminder on="click"}}>Revert</button> --}}
 {{/if}}

--- a/app/templates/index.hbs
+++ b/app/templates/index.hbs
@@ -1,4 +1,4 @@
 <div>
-  <h1>Remember</h1>
+  <h1>Remember Remember</h1>
   {{outlet}}
 </div>

--- a/app/templates/reminders.hbs
+++ b/app/templates/reminders.hbs
@@ -1,15 +1,15 @@
 {{#if model}}
 <ul>
   {{#each model as |reminder|}}
-      <li class="spec-reminder-item">
-        {{#link-to 'reminders.reminder' reminder}}
-          <h2 class="spec-reminder-title">
-              {{reminder.title}}
-          </h2>
-        {{/link-to}}
-        <span class="spec-reminder-date">{{reminder.date}}</span>
-      </li>
-      {{/each}}
+    <li class="spec-reminder-item">
+      {{#link-to 'reminders.reminder' reminder}}
+        <h2 class="spec-reminder-title">
+            {{reminder.title}}
+        </h2>
+      {{/link-to}}
+      <span class="spec-reminder-date">{{reminder.date}}</span>
+    </li>
+    {{/each}}
 </ul>
 {{else}}
   <h3 class="welcome-page-headline">Welcome to Reminders!</h3>

--- a/tests/acceptance/reminder-list-test.js
+++ b/tests/acceptance/reminder-list-test.js
@@ -38,18 +38,6 @@ test('welcome page should render if there are no reminders in the database', fun
   });
 });
 
-test('clicking on the edit button for a reminder will display the submit button for that input field, proving the existence of the input area', function(assert) {
-  server.createList('reminder', 5);
-
-  visit('/');
-  click('.spec-reminder-title');
-  click('.edit-reminder-button');
-
-  andThen(function () {
-    assert.equal(Ember.$('.submit-edits-button').length, 1, 'the submit edits button exists');
-  })
-});
-
 test('clicking "Add a New Reminder" will render a form on the page to add new reminders', function(assert) {
   visit('/reminders/');
   click('.add-reminder-button')
@@ -61,6 +49,18 @@ test('clicking "Add a New Reminder" will render a form on the page to add new re
     assert.equal(find('.edit-reminder-date').length, 1);
     assert.equal(find('.edit-reminder-notes').length, 1);
   });
+});
+
+test('clicking on the edit button for a reminder will display the submit button for that input field, proving the existence of the input area', function(assert) {
+  server.createList('reminder', 5);
+
+  visit('/');
+  click('.spec-reminder-title');
+  click('.edit-reminder-button');
+
+  andThen(function () {
+    assert.equal(Ember.$('.submit-edits-button').length, 1, 'the submit edits button exists');
+  })
 });
 
 test('it properly edits reminders when user enters in new information', function (assert) {
@@ -80,5 +80,36 @@ test('it properly edits reminders when user enters in new information', function
 
   andThen(function () {
     assert.equal(find('.spec-reminder-title:last').text().trim(), 'Sell my car', 'user successfully edits the title of an existing reminder');
+  });
+});
+
+test('it reverts unsaved changes while editing reminders', function (assert) {
+  visit('/');
+  click('.add-reminder-button');
+  fillIn('.edit-reminder-title', 'Pick up kids from school');
+  click('.submit-edits-button');
+  click('.spec-reminder-title');
+
+  andThen(function () {
+    assert.equal(find('.spec-reminder-title:last').text().trim(), 'Pick up kids from school', 'original title shows up');
+  });
+
+  click('.edit-reminder-button');
+  fillIn('.edit-reminder-title', 'Pick up kids from daycare');
+
+  andThen(function () {
+    assert.equal(find('.spec-reminder-title:last').text().trim(), 'Pick up kids from daycare', 'user successfully edits the title of an existing reminder');
+  });
+
+  click('.revert-changes-button');
+
+  andThen(function () {
+    assert.equal(find('.spec-reminder-title:last').text().trim(), 'Pick up kids from school', 'user successfully edits the title of an existing reminder');
+  });
+
+  click('.submit-edits-button');
+
+  andThen(function () {
+    assert.equal(find('.spec-reminder-title:last').text().trim(), 'Pick up kids from school', 'user successfully edits the title of an existing reminder');
   });
 });


### PR DESCRIPTION
## Purpose

_Describe the problem or feature in addition to a link to the issues. Delete any content that doesn't apply._

If a user is editing a reminder, and made a mistake, they should be able to revert those changes back to what was previously saved. 

[Revert Changes Issue](https://github.com/turingschool-projects/1608-remember-8/issues/17)
Closes #17 

## Approach

_How does this change address the problem?_

Users can now revert any unsaved changes to a reminder that they are editing.

### Learning

_Describe the research stage._

_Links to blog posts, patterns, libraries or add-ons used to solve this problem._

We used a few links on ember documentation that indicate rolling back changes that were made. 
[Ember Revert changes] (http://stackoverflow.com/questions/10936007/revert-change-to-ember-data-model)

We also needed to know how to target that particular element:
[Ember's hasDirtyAttributes](http://emberjs.com/api/data/classes/DS.Model.html#property_hasDirtyAttributes)

After first searching editing items with ember, an article provided an example that was very useful in understanding how changes can be reverted:
[Stack Overflow Example](http://stackoverflow.com/questions/10936007/revert-change-to-ember-data-model)

### Test coverage 

_Briefly describe what tests you have written and why._

We wrote one test that shows that when you click the revert-changes-button, your reminder will revert back to its original stored state. (in reminder-list-test)

### Follow-up tasks

- [Issue #2 (Example)](https://github.com/flexyford/pull-request/issues)
